### PR TITLE
Fix HTTP message formatting to be RFC2616 (section 5.1) compliant, an…

### DIFF
--- a/sck_beta_v0_9/Constants.h
+++ b/sck_beta_v0_9/Constants.h
@@ -215,7 +215,7 @@ static char buffer[buffer_length];
 // Basic Server Posts to the SmartCitizen Platform - EndPoint: http://data.smartcitizen.me/add 
 static char* WEB[8]={
                   "data.smartcitizen.me",
-                  "PUT /add HTTP/1.1 \n", 
+                  "PUT /add HTTP/1.1\n", 
                   "Host: data.smartcitizen.me \n", 
                   "User-Agent: SmartCitizen \n", 
                   "X-SmartCitizenMacADDR: ", 
@@ -226,7 +226,7 @@ static char* WEB[8]={
 // Time server request -  EndPoint: http://data.smartcitizen.me/datetime                 
 static char* WEBTIME[3]={                  
                   /*Servidor de tiempo*/
-                  "GET /datetime HTTP/1.1 \n",
+                  "GET /datetime HTTP/1.1\n",
                   "Host: data.smartcitizen.me \n",
                   "User-Agent: SmartCitizen \n\n"  
                   };


### PR DESCRIPTION
Fix HTTP message formatting to be RFC2616 (section 5.1) compliant. 
Hence so they will pass through a transparent Squid proxy.

---

More details:

--------------------------------------------------------------------
Problem The http post syntax.
There should not be a space after HTTP/1.1
--------------------------------------------------------------------
see RFC http://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html
Which says...

"
5.1 Request-Line

The Request-Line begins with a method token, followed by the Request-URI
and the protocol version, and ending with CRLF. The elements are
separated by SP characters. No CR or LF is allowed except in the final
CRLF sequence.

         Request-Line   = Method SP Request-URI SP HTTP-Version CRLF
"

This is also a more readable summary
http://my.safaribooksonline.com/book/networking/security/0201761769/http-1dot1-and-http-1dot0-method-and-field-definitions/app02

In short, remove the space and really the \n should be \r\n
